### PR TITLE
Include both src and include dirs in library target include dirs

### DIFF
--- a/CompileUnits/CompileUnits.cmake
+++ b/CompileUnits/CompileUnits.cmake
@@ -151,11 +151,9 @@ function(compile_units)
         target_include_directories(
           ${NAME}
           PUBLIC
+            $<BUILD_INTERFACE:${SRC_DIR}/src>
             $<BUILD_INTERFACE:${SRC_DIR}/include>
             $<INSTALL_INTERFACE:include>
-          PRIVATE
-            ${SRC_DIR}/include
-            ${SRC_DIR}/src
         )
         if(EXISTS ${SRC_DIR}/include/)
           install(


### PR DESCRIPTION
This change makes sure that header files in the `src` directory are discoverable by dependent targets.