### PR TITLE
Disable BUILD_TESTS option by default

### DIFF
--- a/CompileUnits/CompileUnits.cmake
+++ b/CompileUnits/CompileUnits.cmake
@@ -16,7 +16,7 @@ if(NOT googletest_POPULATED)
   set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES CXX_CLANG_TIDY "" CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
 endif()
 
-option(BUILD_TESTS "Build tests" ON)
+option(BUILD_TESTS "Build tests" OFF)
 
 define_property(GLOBAL PROPERTY FCM BRIEF_DOCS "." FULL_DOCS ".")
 

--- a/CompileUnits/example/CMakeLists.txt
+++ b/CompileUnits/example/CMakeLists.txt
@@ -20,6 +20,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/..)
 
 include(CompileUnits)
 
+# Enable tests
+SET(BUILD_TESTS ON CACHE BOOL "")
+
 # Add all directories with `CMakeLists.txt` files which add compile units.
 add_subdirectory(src)
 


### PR DESCRIPTION
It makes more sense to disable this option by default, until there is some logic to link tests to targets and have them disabled for optional units.