### PR TITLE
Add install COMPONENT support to compile units

### DIFF
--- a/CompileUnits/CompileUnits.cmake
+++ b/CompileUnits/CompileUnits.cmake
@@ -38,8 +38,9 @@ function(add_compile_unit)
     OPT   # Mark unit as optional. Ignored for tests.
   )
   set(single
-    NAME  # Target name
-    TYPE  # Compile unit type: SHARED | OBJECT | EXECUTABLE | TESTS | INTERFACE | BENCHMARK
+    NAME      # Target name
+    TYPE      # Compile unit type: SHARED | OBJECT | EXECUTABLE | TESTS | INTERFACE | BENCHMARK
+    COMPONENT # Group name
   )
   set(multi
     SRCS  # List of sources
@@ -53,6 +54,10 @@ function(add_compile_unit)
   # Default behavior is OBJECT_LIBRARY
   if(NOT X_TYPE)
     set(X_TYPE OBJECT)
+  endif()
+
+  if(NOT X_COMPONENT)
+    set(X_COMPONENT "Unspecified")
   endif()
 
   # test shortcut
@@ -119,6 +124,7 @@ function(add_compile_unit)
   # single
   set_property(GLOBAL PROPERTY FCM_${X_NAME}_NAME ${X_NAME})
   set_property(GLOBAL PROPERTY FCM_${X_NAME}_TYPE ${X_TYPE})
+  set_property(GLOBAL PROPERTY FCM_${X_NAME}_COMPONENT ${X_COMPONENT})
   # multi
   set_property(GLOBAL PROPERTY FCM_${X_NAME}_SRCS ${X_SRCS})
   set_property(GLOBAL PROPERTY FCM_${X_NAME}_DEPS ${X_DEPS})
@@ -216,6 +222,7 @@ function(compile_units)
       # single
       get_property(NAME GLOBAL PROPERTY ${LIB}_NAME)
       get_property(TYPE GLOBAL PROPERTY ${LIB}_TYPE)
+      get_property(COMPONENT GLOBAL PROPERTY ${LIB}_COMPONENT)
       # multi
       get_property(SRCS GLOBAL PROPERTY ${LIB}_SRCS)
       get_property(PRPS GLOBAL PROPERTY ${LIB}_PRPS)
@@ -269,6 +276,7 @@ function(compile_units)
         endif()
         if(EXISTS ${SRC_DIR}/include/)
           install(
+            COMPONENT ${COMPONENT}
             DIRECTORY ${SRC_DIR}/include/
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           )
@@ -277,6 +285,7 @@ function(compile_units)
           # shared libraries are installed
           install(
             TARGETS ${NAME}
+            COMPONENT ${COMPONENT}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           )
@@ -302,6 +311,7 @@ function(compile_units)
         if (${TYPE} MATCHES EXECUTABLE)
           install(
             TARGETS ${NAME}
+            COMPONENT ${COMPONENT}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           )
         endif()

--- a/CompileUnits/CompileUnits.cmake
+++ b/CompileUnits/CompileUnits.cmake
@@ -276,18 +276,18 @@ function(compile_units)
         endif()
         if(EXISTS ${SRC_DIR}/include/)
           install(
-            COMPONENT ${COMPONENT}
             DIRECTORY ${SRC_DIR}/include/
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            COMPONENT ${COMPONENT}
           )
         endif()
         if(${TYPE} MATCHES SHARED)
           # shared libraries are installed
           install(
             TARGETS ${NAME}
-            COMPONENT ${COMPONENT}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT ${COMPONENT}
           )
         endif()
         if(${TYPE} MATCHES OBJECT)
@@ -311,8 +311,8 @@ function(compile_units)
         if (${TYPE} MATCHES EXECUTABLE)
           install(
             TARGETS ${NAME}
-            COMPONENT ${COMPONENT}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT ${COMPONENT}
           )
         endif()
         if (${TYPE} MATCHES TESTS)

--- a/CompileUnits/example/src/bin/app/CMakeLists.txt
+++ b/CompileUnits/example/src/bin/app/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_compile_unit(
   NAME example::app
   TYPE EXECUTABLE
+  COMPONENT bins
   SRCS
     src/main.cpp
   TSTS

--- a/CompileUnits/example/src/bin/cli/CMakeLists.txt
+++ b/CompileUnits/example/src/bin/cli/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_compile_unit(
   NAME example::cli
   TYPE EXECUTABLE
+  COMPONENT bins
   SRCS
     src/main.cpp
   DEPS

--- a/CompileUnits/example/src/lib/CMakeLists.txt
+++ b/CompileUnits/example/src/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(interface)
 add_compile_unit(
   NAME example::lib
   TYPE SHARED
+  COMPONENT libs
   DEPS
     example::lib::a
     example::lib::b


### PR DESCRIPTION
This adds a `COMPONENT` option to compile units to specify a component group used for installation with CPack.